### PR TITLE
feat: allow buyers to add their QR without going to admin page[iteration-2]

### DIFF
--- a/marketplace/urls.py
+++ b/marketplace/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('transaction-history', views.seller_view_order_history, name='transaction-history'),
     path('orders/<int:id>/', views.order_detail, name='buyer_order_detail'),
     path('transaction-detail/<int:pk>/', views.transaction_detail, name='transaction_detail'),
+    path('store/payments/edit/', views.edit_store_payments, name='edit_store_payments'),
     path('orders/', views.order_history, name='order_history'),
     path('track/', views.track_list, name='track_list')
 ]

--- a/marketplace/views.py
+++ b/marketplace/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from .models import Product, Cart, Order
-from .forms import ProductForm, CheckoutForm
+from .forms import ProductForm, CheckoutForm, StorePaymentForm
 
 
 @login_required
@@ -217,6 +217,33 @@ def seller_view_order_history(request):
         'orders': orders
     })
 
+
+@login_required
+def edit_store_payments(request):
+    """View for a seller to upload their receiving QR codes."""
+    # Ensure only sellers can access this view
+    if request.user.user_type != 'S':
+        raise PermissionDenied("Only sellers can update store payment methods.")
+
+    # Fetch the store associated with the logged-in seller
+    store = request.user.store
+
+    if request.method == 'POST':
+        # Pass request.FILES because the form handles image uploads
+        form = StorePaymentForm(request.POST, request.FILES, instance=store)
+        if form.is_valid():
+            form.save()
+            # Redirect back to the transaction history or store dashboard upon success
+            return redirect('marketplace:transaction-history')
+    else:
+        # Pre-populate the form with existing QR codes if the seller already uploaded them
+        form = StorePaymentForm(instance=store)
+
+    return render(request, 'store_payment_form.html', {
+        'form': form,
+    })
+
+
 def order_detail(request, id):
     """View for the buyer's individual order"""
     order = Order.objects.get(id=id)
@@ -224,7 +251,12 @@ def order_detail(request, id):
         raise PermissionDenied("This is not your order!")
     
     status = order.get_status_display()
-    return render(request, 'buyer_order_detail.html', {'order': order, 'status': status})
+    return render(request, 'buyer_order_detail.html', {
+        'order': order,
+        'status': status
+    })
+
+
 @login_required
 def transaction_detail(request, pk):
     """View for the transaction detail page."""
@@ -248,14 +280,20 @@ def transaction_detail(request, pk):
         order.save()
         return redirect('marketplace:transaction_detail', pk=pk)
     
-    return render(request, 'transaction_detail.html', {'order': order})
+    return render(request, 'transaction_detail.html',{
+        'order': order
+    })
+
 
 @login_required
 def order_history(request):
     """View for the buyer's order history page."""
     # This fetches orders that the logged-in user has made
     buyer_orders = Order.objects.filter(buyer=request.user).order_by('-date')
-    return render(request, 'order_history.html', {'orders': buyer_orders})
+    return render(request, 'order_history.html',{
+        'orders': buyer_orders
+    })
+
 
 def track_list(request):
     """View for the seller's product tracking list"""

--- a/templates/store_payment_form.html
+++ b/templates/store_payment_form.html
@@ -1,0 +1,56 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}Update Store Payments | Buy The Way{% endblock %}
+
+{% block stylesheet %}
+<style>
+    .payment-form-container {
+        max-width: 600px;
+        margin: 2rem auto;
+        padding: 2rem;
+        border: 1px solid #ccc;
+        border-radius: 8px;
+        background-color: #f9f9f9;
+    }
+    .payment-form-container h2 {
+        margin-bottom: 1.5rem;
+        text-align: center;
+    }
+    .form-group {
+        margin-bottom: 1.5rem;
+    }
+    .submit-btn {
+        width: 100%;
+        padding: 0.75rem;
+        background-color: #4CAF50;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        font-size: 1rem;
+        cursor: pointer;
+    }
+    .submit-btn:hover {
+        background-color: #45a049;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="payment-form-container">
+    <h2>Update Store Payment Methods</h2>
+    <p style="text-align: center; margin-bottom: 1.5rem;">
+        Upload your QR codes below so buyers can easily pay you via GCash, Maya, or Bank Transfer.
+    </p>
+
+    <form method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+        
+        <div class="form-group">
+            {{ form.as_p }}
+        </div>
+
+        <button type="submit" class="submit-btn">Save Payment Methods</button>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
- add a view under `marketplace/views.py` to handle StorePaymentForm.
- Buyer does not need to go to admin page to input their QR.
<img width="2560" height="1536" alt="image" src="https://github.com/user-attachments/assets/1a251d9c-6438-4881-8cc6-e148d11c9777" />
