### PR TITLE
hotfix: add missing comma in installedapps

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -46,7 +46,7 @@ INSTALLED_APPS = [
     'apps',
     'account_management',
     'marketplace',
-    'watson'
+    'watson',
     'chat',
 ]
 


### PR DESCRIPTION
- added missing "," in `INSTALLED_APPS`