### PR TITLE
feat: upload files to chat[iteration-3]

### DIFF
--- a/chat/models.py
+++ b/chat/models.py
@@ -55,7 +55,8 @@ class Message(models.Model):
         on_delete=models.CASCADE,
         related_name='sent_messages',
     )
-    content = models.TextField()
+    content = models.TextField(blank=True)
+    attachment = models.FileField(upload_to='chat_attachments/', blank=True, null=True)
     timestamp = models.DateTimeField(auto_now_add=True)
     is_read = models.BooleanField(default=False)
 

--- a/chat/views.py
+++ b/chat/views.py
@@ -80,19 +80,25 @@ def send_message(request, pk):
     if user != conversation.buyer and user != conversation.seller:
         return JsonResponse({'error': 'Forbidden'}, status=403)
 
-    try:
-        data = json.loads(request.body)
-        content = data.get('content', '').strip()
-    except (json.JSONDecodeError, AttributeError):
+    attachment = None
+    if request.content_type and 'multipart' in request.content_type:
         content = request.POST.get('content', '').strip()
+        attachment = request.FILES.get('attachment')
+    else:
+        try:
+            data = json.loads(request.body)
+            content = data.get('content', '').strip()
+        except (json.JSONDecodeError, AttributeError):
+            content = request.POST.get('content', '').strip()
 
-    if not content:
+    if not content and not attachment:
         return JsonResponse({'error': 'Empty message'}, status=400)
 
     message = Message.objects.create(
         conversation=conversation,
         sender=user,
         content=content,
+        attachment=attachment,
     )
 
     return JsonResponse({
@@ -103,6 +109,8 @@ def send_message(request, pk):
             user.profile_picture.url if user.profile_picture else None
         ),
         'content': message.content,
+        'attachment_url': message.attachment.url if message.attachment else None,
+        'attachment_name': message.attachment.name.split('/')[-1] if message.attachment else None,
         'timestamp': message.timestamp.strftime('%b %d, %Y %H:%M'),
     })
 
@@ -133,6 +141,8 @@ def poll_messages(request, pk):
                 else None
             ),
             'content': m.content,
+            'attachment_url': m.attachment.url if m.attachment else None,
+            'attachment_name': m.attachment.name.split('/')[-1] if m.attachment else None,
             'timestamp': m.timestamp.strftime('%b %d, %Y %H:%M'),
         }
         for m in new_messages

--- a/static/css/chat.css
+++ b/static/css/chat.css
@@ -381,6 +381,101 @@
     background: var(--check-out-blue);
 }
 
+.chat-attachment-preview {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 16px;
+    background: #eef2ff;
+    border-top: 1px solid var(--border-gray);
+    font-size: 14px;
+    color: var(--text-dark);
+}
+
+.chat-attachment-preview span {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.attachment-preview-thumb {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.attachment-thumb-img {
+    width: 48px;
+    height: 48px;
+    object-fit: cover;
+    border-radius: 6px;
+    border: 1px solid var(--border-gray);
+    display: block;
+}
+
+.attachment-thumb-file {
+    width: 48px;
+    height: 48px;
+    background: #fff;
+    border: 1px solid var(--border-gray);
+    border-radius: 6px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1px;
+}
+
+.attachment-thumb-icon {
+    font-size: 22px;
+    line-height: 1;
+}
+
+.attachment-thumb-label {
+    font-size: 9px;
+    font-weight: 700;
+    color: var(--primary-blue);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+#attachment-clear-btn {
+    border: none;
+    background: transparent;
+    font-size: 18px;
+    cursor: pointer;
+    color: #888;
+    line-height: 1;
+    padding: 0 4px;
+}
+
+#attachment-clear-btn:hover {
+    color: #333;
+}
+
+.message-attachment-img {
+    display: block;
+    max-width: 240px;
+    max-height: 240px;
+    border-radius: 10px;
+    margin-top: 4px;
+    object-fit: cover;
+}
+
+.message-attachment-file {
+    display: inline-block;
+    margin-top: 4px;
+    color: inherit;
+    text-decoration: underline;
+    word-break: break-all;
+}
+
+.message-mine .message-attachment-file {
+    color: #d0e4ff;
+}
+
 /* ── Chat with Seller button (product detail) ── */
 .chat-seller-btn {
     display: inline-block;

--- a/templates/chat/conversation.html
+++ b/templates/chat/conversation.html
@@ -31,20 +31,38 @@
                     {% endif %}
                 </div>
                 <div class="message-body">
-                    <p class="message-content">{{ message.content }}</p>
+                    <div class="message-content">
+                        {% if message.content %}{{ message.content }}{% endif %}
+                        {% if message.attachment %}
+                            {% with ext=message.attachment.name|lower %}
+                                {% if ".jpg" in ext or ".jpeg" in ext or ".png" in ext or ".gif" in ext or ".webp" in ext %}
+                                    <img class="message-attachment-img" src="{{ message.attachment.url }}" alt="image attachment">
+                                {% else %}
+                                    <a class="message-attachment-file" href="{{ message.attachment.url }}" target="_blank" rel="noopener">&#128206; {{ message.attachment.name|cut:"chat_attachments/" }}</a>
+                                {% endif %}
+                            {% endwith %}
+                        {% endif %}
+                    </div>
                     <span class="message-time">{{ message.timestamp|date:"M d, H:i" }}</span>
                 </div>
             </div>
         {% endfor %}
     </div>
 
+    <input type="file" id="image-input" accept="image/*" style="display:none">
+    <input type="file" id="file-input" style="display:none">
+    <div class="chat-attachment-preview" id="attachment-preview" style="display:none">
+        <div class="attachment-preview-thumb" id="attachment-preview-thumb"></div>
+        <span id="attachment-preview-name"></span>
+        <button type="button" id="attachment-clear-btn" aria-label="Remove attachment">&times;</button>
+    </div>
     <form class="chat-input-form" id="chat-form">
         {% csrf_token %}
         <div class="chat-input-actions" aria-label="Attachment actions">
-            <button type="button" class="chat-icon-btn" aria-label="Add image">
+            <button type="button" class="chat-icon-btn" id="image-btn" aria-label="Add image">
                 <img src="{% static 'icons/image.png' %}" alt="" class="chat-input-icon">
             </button>
-            <button type="button" class="chat-icon-btn" aria-label="Attach file">
+            <button type="button" class="chat-icon-btn" id="file-btn" aria-label="Attach file">
                 <img src="{% static 'icons/paperclip.png' %}" alt="" class="chat-input-icon">
             </button>
         </div>
@@ -67,6 +85,78 @@
     const messagesDiv = document.getElementById('chat-messages');
     const form = document.getElementById('chat-form');
     const input = document.getElementById('chat-input');
+    const imageInput = document.getElementById('image-input');
+    const fileInput = document.getElementById('file-input');
+    const attachmentPreview = document.getElementById('attachment-preview');
+    const attachmentPreviewName = document.getElementById('attachment-preview-name');
+    const attachmentPreviewThumb = document.getElementById('attachment-preview-thumb');
+    const attachmentClearBtn = document.getElementById('attachment-clear-btn');
+
+    let pendingFile = null;
+
+    const FILE_TYPE_ICONS = {
+        pdf:  { icon: '📄', label: 'PDF' },
+        doc:  { icon: '📝', label: 'DOC' },
+        docx: { icon: '📝', label: 'DOCX' },
+        xls:  { icon: '📊', label: 'XLS' },
+        xlsx: { icon: '📊', label: 'XLSX' },
+        ppt:  { icon: '📊', label: 'PPT' },
+        pptx: { icon: '📊', label: 'PPTX' },
+        zip:  { icon: '🗜️', label: 'ZIP' },
+        rar:  { icon: '🗜️', label: 'RAR' },
+        mp4:  { icon: '🎬', label: 'MP4' },
+        mp3:  { icon: '🎵', label: 'MP3' },
+        txt:  { icon: '📃', label: 'TXT' },
+    };
+
+    document.getElementById('image-btn').addEventListener('click', () => imageInput.click());
+    document.getElementById('file-btn').addEventListener('click', () => fileInput.click());
+
+    function setPendingFile(file) {
+        pendingFile = file;
+        attachmentPreviewName.textContent = file.name;
+        attachmentPreviewThumb.innerHTML = '';
+
+        const ext = file.name.split('.').pop().toLowerCase();
+        const isImage = /^(jpg|jpeg|png|gif|webp)$/.test(ext);
+
+        if (isImage) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                const img = document.createElement('img');
+                img.src = e.target.result;
+                img.className = 'attachment-thumb-img';
+                img.alt = file.name;
+                attachmentPreviewThumb.appendChild(img);
+            };
+            reader.readAsDataURL(file);
+        } else {
+            const info = FILE_TYPE_ICONS[ext] || { icon: '📎', label: ext.toUpperCase() || 'FILE' };
+            attachmentPreviewThumb.innerHTML =
+                `<div class="attachment-thumb-file"><span class="attachment-thumb-icon">${info.icon}</span><span class="attachment-thumb-label">${info.label}</span></div>`;
+        }
+
+        attachmentPreview.style.display = 'flex';
+    }
+
+    function clearPendingFile() {
+        pendingFile = null;
+        imageInput.value = '';
+        fileInput.value = '';
+        attachmentPreview.style.display = 'none';
+        attachmentPreviewName.textContent = '';
+        attachmentPreviewThumb.innerHTML = '';
+    }
+
+    imageInput.addEventListener('change', () => {
+        if (imageInput.files[0]) setPendingFile(imageInput.files[0]);
+    });
+
+    fileInput.addEventListener('change', () => {
+        if (fileInput.files[0]) setPendingFile(fileInput.files[0]);
+    });
+
+    attachmentClearBtn.addEventListener('click', clearPendingFile);
 
     // Track the last message id for polling
     let lastMessageId = 0;
@@ -79,6 +169,15 @@
         messagesDiv.scrollTop = messagesDiv.scrollHeight;
     }
     scrollToBottom();
+
+    function buildAttachmentHtml(attachmentUrl, attachmentName) {
+        if (!attachmentUrl) return '';
+        const lower = attachmentName ? attachmentName.toLowerCase() : attachmentUrl.toLowerCase();
+        if (/\.(jpg|jpeg|png|gif|webp)$/.test(lower)) {
+            return `<img class="message-attachment-img" src="${escapeHtml(attachmentUrl)}" alt="image attachment">`;
+        }
+        return `<a class="message-attachment-file" href="${escapeHtml(attachmentUrl)}" target="_blank" rel="noopener">&#128206; ${escapeHtml(attachmentName || 'attachment')}</a>`;
+    }
 
     function appendMessage(msg, isMine) {
         const div = document.createElement('div');
@@ -93,10 +192,13 @@
             ? `<img class="message-avatar" src="${escapeHtml(avatarUrl)}" alt="${escapeHtml(senderName)} profile photo">`
             : `<div class="message-avatar message-avatar-fallback">${fallbackInitial}</div>`;
 
+        const attachmentHtml = buildAttachmentHtml(msg.attachment_url, msg.attachment_name);
+        const contentHtml = msg.content ? escapeHtml(msg.content) : '';
+
         div.innerHTML = `
             <div class="message-avatar-wrap">${avatarHtml}</div>
             <div class="message-body">
-                <p class="message-content">${escapeHtml(msg.content)}</p>
+                <div class="message-content">${contentHtml}${attachmentHtml}</div>
                 <span class="message-time">${msg.timestamp}</span>
             </div>
         `;
@@ -113,24 +215,40 @@
     form.addEventListener('submit', function (e) {
         e.preventDefault();
         const content = input.value.trim();
-        if (!content) return;
+        if (!content && !pendingFile) return;
 
-        fetch(sendUrl, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': csrfToken,
-            },
-            body: JSON.stringify({ content }),
-        })
-        .then(r => r.json())
-        .then(msg => {
-            if (msg.id) {
-                appendMessage(msg, true);
-                lastMessageId = msg.id;
-                input.value = '';
-            }
-        });
+        let fetchOptions;
+        if (pendingFile) {
+            const formData = new FormData();
+            formData.append('csrfmiddlewaretoken', csrfToken);
+            formData.append('content', content);
+            formData.append('attachment', pendingFile);
+            fetchOptions = {
+                method: 'POST',
+                headers: { 'X-CSRFToken': csrfToken },
+                body: formData,
+            };
+        } else {
+            fetchOptions = {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrfToken,
+                },
+                body: JSON.stringify({ content }),
+            };
+        }
+
+        fetch(sendUrl, fetchOptions)
+            .then(r => r.json())
+            .then(msg => {
+                if (msg.id) {
+                    appendMessage(msg, true);
+                    lastMessageId = msg.id;
+                    input.value = '';
+                    clearPendingFile();
+                }
+            });
     });
 
     function poll() {


### PR DESCRIPTION
- `paperclip.png` and `image.png` now allow the user to upload files to chat
- uploaded files are previewed before uploading to chat
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e2426677-8693-4d4f-b984-43c5071ac532" />
