### PR TITLE
fix: code expiration message shows up

### DIFF
--- a/account_management/templates/registration/verify_email.html
+++ b/account_management/templates/registration/verify_email.html
@@ -110,6 +110,12 @@
             font-size: 1rem;
             font-weight: 500;
             color: #111;
+            margin-bottom: 0.8rem;
+        }
+
+        .card p.expiry-notice {
+            font-size: 0.9rem;
+            color: #777;
             margin-bottom: 1.8rem;
         }
 
@@ -217,6 +223,7 @@
             <p class="intro">We have sent an e-mail to your email address:</p>
             <p class="masked-email">{{ masked_email }}</p>
             <p class="instruction">Kindly check your inbox and enter the 6-digit code below:</p>
+            <p class="expiry-notice">This code expires in <strong>10 minutes</strong>.</p>
 
             {% if messages %}
                 {% for message in messages %}


### PR DESCRIPTION
- Added a small message that OTP will expire in 10 minutes
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/a067466b-2441-4352-9378-50e840216930" />
